### PR TITLE
refactor(dependabot): Update Dependabot and CI config for better dependency management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,109 @@
 version: 2
 updates:
+  # Backend production dependencies
   - package-ecosystem: "pip"
     directory: "/backend"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "09:00"
     allow:
-      - dependency-type: "all"
-    open-pull-requests-limit: 10
+      - dependency-type: "production"
+    open-pull-requests-limit: 3
+    groups:
+      backend-prod:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    reviewers:
+      - "talberry"
+    assignees:
+      - "talberry"
+
+  # Backend development dependencies
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    allow:
+      - dependency-type: "development"
+    open-pull-requests-limit: 2
+    groups:
+      backend-dev:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    reviewers:
+      - "talberry"
+    assignees:
+      - "talberry"
+
+  # Frontend production dependencies
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "09:00"
     allow:
-      - dependency-type: "all"
-    open-pull-requests-limit: 10
+      - dependency-type: "production"
+    open-pull-requests-limit: 3
+    groups:
+      frontend-prod:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    reviewers:
+      - "talberry"
+    assignees:
+      - "talberry"
+
+  # Frontend development dependencies
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    allow:
+      - dependency-type: "development"
+    open-pull-requests-limit: 2
+    groups:
+      frontend-dev:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    reviewers:
+      - "talberry"
+    assignees:
+      - "talberry"
+
+  # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 2
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    reviewers:
+      - "talberry"
+    assignees:
+      - "talberry"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,14 +39,15 @@ jobs:
       - name: Get branch expiration date (2 weeks from now)
         id: get_expiration_date
         run: echo "EXPIRES_AT=$(date -u --date '+14 days' +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_ENV"
+      
       - name: Create Neon Branch
         id: create_neon_branch
         uses: neondatabase/create-branch-action@v6
         with: 
-            project_id: ${{ vars.NEON_PROJECT_ID }}
-            branch_name: preview/pr-${{ github.event.number }}-${{ needs.setup.outputs.branch }}
-            api_key: ${{ secrets.NEON_API_KEY }}
-            expires_at: ${{ env.EXPIRES_AT }}
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch_name: preview/pr-${{ github.event.number }}-${{ needs.setup.outputs.branch }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+          expires_at: ${{ env.EXPIRES_AT }}
 
   delete_neon_branch:
     name: Delete Neon Branch
@@ -64,7 +65,7 @@ jobs:
   backend:
     runs-on: ubuntu-latest
     needs: create_neon_branch
-    if: always() && (needs.create_neon_branch.result == 'success' || needs.create_neon_branch.result == 'skipped')
+    if: needs.create_neon_branch.result == 'success' || needs.create_neon_branch.result == 'skipped'
     strategy:
       matrix:
         python-version: [3.11, 3.13]

--- a/backend/adaptive_testing/settings/ci.py
+++ b/backend/adaptive_testing/settings/ci.py
@@ -11,19 +11,15 @@ from decouple import config
 from .base import *  # noqa: F403, F401
 
 # Database configuration
-# Use Neon database if DATABASE_URL is set, otherwise use a simple file-based SQLite
-if config("DATABASE_URL", default=None):
-    import dj_database_url
-    DATABASES = {
-        "default": dj_database_url.parse(config("DATABASE_URL"))
-    }
-else:
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.sqlite3",
-            "NAME": "/tmp/test_ci.db",
-        }
-    }
+# Always use Neon database for CI - fail if not available
+import dj_database_url
+DATABASE_URL = config("DATABASE_URL", default=None)
+if not DATABASE_URL:
+    raise ValueError("DATABASE_URL is required for CI environment. Neon branch creation may have failed.")
+
+DATABASES = {
+    "default": dj_database_url.parse(DATABASE_URL)
+}
 
 # Disable password hashing for faster CI
 PASSWORD_HASHERS = [


### PR DESCRIPTION
## Description
Updated dependabot workflow to group dependency updates better to limit the number of open PRs. Also, removed SQLite as a fallback db (to ensure everything works on Neon). 

## Changes Made
- Group Dependabot PRs and reduce limits (max 12 PRs vs 30+)
- Update Neon actions and remove SQLite fallback
- Fail fast on branch limit with manual rerun capability
- Separate prod/dev dependencies with scheduled updates
